### PR TITLE
removed overlay

### DIFF
--- a/Website/app/templates/page_main.html
+++ b/Website/app/templates/page_main.html
@@ -24,11 +24,6 @@
             <a href="{{ url_for('view_request', request_id=job.id) }}">View Job</a>
         </div>
         {% endfor %}
-        <div id="overlay" onclick="onOverlayClick()">
-            <div class="overlay-content">
-                <textarea readonly>Overlay opened successfully</textarea>
-            </div>
-        </div>
     </div>
     </section>
     {% endif %}


### PR DESCRIPTION
removed this so that when you click on the the text it doesnt create an overlay, so instead you have to click on "View job"